### PR TITLE
Added Chainbridge pallet to Dusty runtime.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4038,6 +4038,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-assets"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e4ad8ad50df73d1bc99f6a67bfbe84e8be1554019a798ba37db958f9ad4cc9"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-authorship"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5053,6 +5068,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "hex-literal",
  "lazy_static",
+ "pallet-assets",
  "pallet-authorship",
  "pallet-babe",
  "pallet-balances",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "chainbridge"
+version = "0.0.2"
+source = "git+https://github.com/ChainSafe/chainbridge-substrate#39990274866fd3b759aa9aa9d883da499ff3d6ea"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "substrate-wasm-builder-runner 2.0.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5027,6 +5044,7 @@ dependencies = [
 name = "plasm-runtime"
 version = "1.10.0"
 dependencies = [
+ "chainbridge",
  "evm",
  "fp-rpc",
  "frame-executive",
@@ -5083,7 +5101,7 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "substrate-wasm-builder-runner",
+ "substrate-wasm-builder-runner 1.0.6",
 ]
 
 [[package]]
@@ -7976,6 +7994,12 @@ name = "substrate-wasm-builder-runner"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
+
+[[package]]
+name = "substrate-wasm-builder-runner"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54cab12167e32b38a62c5ea5825aa0874cde315f907a46aad2b05aa8ef3d862f"
 
 [[package]]
 name = "subtle"

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -212,6 +212,11 @@ pub fn dusty_config() -> ChainSpec {
     ChainSpec::from_json_bytes(&include_bytes!("../res/dusty.raw.json")[..]).unwrap()
 }
 
+/// Dusty testnet file config.
+pub fn dusty5_config() -> ChainSpec {
+    ChainSpec::from_json_bytes(&include_bytes!("../res/dusty5.raw.json")[..]).unwrap()
+}
+
 /*
 /// Dusty native config.
 pub fn dusty_config() -> ChainSpec {

--- a/bin/node/cli/src/command.rs
+++ b/bin/node/cli/src/command.rs
@@ -34,6 +34,7 @@ impl SubstrateCli for Cli {
             "dev" => Box::new(chain_spec::development_config()),
             "local" => Box::new(chain_spec::local_testnet_config()),
             "" | "dusty" => Box::new(chain_spec::dusty_config()),
+            "dusty5" => Box::new(chain_spec::dusty5_config()),
             "plasm" => Box::new(chain_spec::plasm_config()),
             path => Box::new(chain_spec::ChainSpec::from_json_file(
                 std::path::PathBuf::from(path),

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -40,6 +40,7 @@ pallet-evm-precompile-modexp = { path = "../../../vendor/frontier/frame/evm/prec
 pallet-evm-precompile-dispatch = { path = "../../../vendor/frontier/frame/evm/precompile/dispatch", default-features = false }
 pallet-dusty-chainbridge = { package = "chainbridge",git = "https://github.com/ChainSafe/chainbridge-substrate", default-features = false }
 frame-executive = { version = "3.0.0", default-features = false }
+pallet-assets = { version = "3.0.0", default-features = false }
 pallet-authorship = { version = "3.0.0", default-features = false }
 pallet-babe = { version = "3.0.0", default-features = false }
 pallet-balances = { version = "3.0.0", default-features = false }
@@ -116,6 +117,7 @@ std = [
     "pallet-indices/std",
     "pallet-im-online/std",
     "pallet-nicks/std",
+    "pallet-assets/std",
     "pallet-custom-signatures/std",
     "pallet-randomness-collective-flip/std",
     "pallet-scheduler/std",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -129,5 +129,5 @@ std = [
     "pallet-offences/std",
     "pallet-vesting/std",
     "pallet-staking/std",
-	"pallet-dusty-chainbridge/std",
+    "pallet-dusty-chainbridge/std",
 ]

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -38,7 +38,6 @@ pallet-evm-precompile-bn128 = { path = "../../../vendor/frontier/frame/evm/preco
 pallet-evm-precompile-simple = { path = "../../../vendor/frontier/frame/evm/precompile/simple", default-features = false }
 pallet-evm-precompile-modexp = { path = "../../../vendor/frontier/frame/evm/precompile/modexp", default-features = false }
 pallet-evm-precompile-dispatch = { path = "../../../vendor/frontier/frame/evm/precompile/dispatch", default-features = false }
-# pallet-dusty-chainbridge = { path = '../../../frame/chainbridge', default_features = false }
 pallet-dusty-chainbridge = { package = "chainbridge",git = "https://github.com/ChainSafe/chainbridge-substrate", default-features = false }
 frame-executive = { version = "3.0.0", default-features = false }
 pallet-authorship = { version = "3.0.0", default-features = false }
@@ -130,5 +129,5 @@ std = [
     "pallet-offences/std",
     "pallet-vesting/std",
     "pallet-staking/std",
-	'pallet-dusty-chainbridge/std',
+	"pallet-dusty-chainbridge/std",
 ]

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -38,6 +38,8 @@ pallet-evm-precompile-bn128 = { path = "../../../vendor/frontier/frame/evm/preco
 pallet-evm-precompile-simple = { path = "../../../vendor/frontier/frame/evm/precompile/simple", default-features = false }
 pallet-evm-precompile-modexp = { path = "../../../vendor/frontier/frame/evm/precompile/modexp", default-features = false }
 pallet-evm-precompile-dispatch = { path = "../../../vendor/frontier/frame/evm/precompile/dispatch", default-features = false }
+# pallet-dusty-chainbridge = { path = '../../../frame/chainbridge', default_features = false }
+pallet-dusty-chainbridge = { package = "chainbridge",git = "https://github.com/ChainSafe/chainbridge-substrate", default-features = false }
 frame-executive = { version = "3.0.0", default-features = false }
 pallet-authorship = { version = "3.0.0", default-features = false }
 pallet-babe = { version = "3.0.0", default-features = false }
@@ -127,5 +129,6 @@ std = [
     "pallet-utility/std",
     "pallet-offences/std",
     "pallet-vesting/std",
-    "pallet-staking/std"
+    "pallet-staking/std",
+	'pallet-dusty-chainbridge/std',
 ]

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -757,6 +757,19 @@ impl pallet_identity::Config for Runtime {
     type WeightInfo = ();
 }
 
+parameter_types! {
+	pub const BridgeChainId: u8 = 80;
+	pub const ProposalLifetime: BlockNumber = 1000;
+}
+
+impl pallet_dusty_chainbridge::Config for Runtime {
+	type Event = Event;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type Proposal = Call;
+	type ChainId = BridgeChainId;
+	type ProposalLifetime = ProposalLifetime;
+}
+
 construct_runtime!(
     pub enum Runtime where
         Block = Block,
@@ -787,6 +800,7 @@ construct_runtime!(
         Ethereum: pallet_ethereum::{Module, Call, Storage, Event, Config, ValidateUnsigned},
         EVM: pallet_evm::{Module, Call, Storage, Config, Event<T>},
         EthCall: pallet_custom_signatures::{Module, Call, Event<T>, ValidateUnsigned},
+		ChainBridge: pallet_dusty_chainbridge::{Module, Call, Storage, Event<T>},
     }
 );
 

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -78,7 +78,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to equal spec_version. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 4,
+    spec_version: 5,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -78,7 +78,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to equal spec_version. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 3,
+    spec_version: 4,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -800,7 +800,7 @@ construct_runtime!(
         Ethereum: pallet_ethereum::{Module, Call, Storage, Event, Config, ValidateUnsigned},
         EVM: pallet_evm::{Module, Call, Storage, Config, Event<T>},
         EthCall: pallet_custom_signatures::{Module, Call, Event<T>, ValidateUnsigned},
-		ChainBridge: pallet_dusty_chainbridge::{Module, Call, Storage, Event<T>},
+        ChainBridge: pallet_dusty_chainbridge::{Module, Call, Storage, Event<T>},
     }
 );
 

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -770,6 +770,26 @@ impl pallet_dusty_chainbridge::Config for Runtime {
 	type ProposalLifetime = ProposalLifetime;
 }
 
+parameter_types! {
+	pub const StringLimit: u32 = 50;
+	pub const MetadataDepositBase: Balance = 10 * PLM;
+	pub const MetadataDepositPerByte: Balance = 10 * MILLIPLM;
+}
+
+impl pallet_assets::Config for Runtime {
+	type Event = Event;
+	type Balance = Balance;
+	type AssetId = u32;
+	type Currency = Balances;
+	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
+	type MetadataDepositBase = MetadataDepositBase;
+	type MetadataDepositPerByte = MetadataDepositPerByte;
+	type StringLimit = StringLimit;
+    type AssetDepositBase = ();
+    type AssetDepositPerZombie = ();
+	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+}
+
 construct_runtime!(
     pub enum Runtime where
         Block = Block,
@@ -801,6 +821,7 @@ construct_runtime!(
         EVM: pallet_evm::{Module, Call, Storage, Config, Event<T>},
         EthCall: pallet_custom_signatures::{Module, Call, Event<T>, ValidateUnsigned},
         ChainBridge: pallet_dusty_chainbridge::{Module, Call, Storage, Event<T>},
+		Assets: pallet_assets::{Module, Call, Storage, Event<T>},
     }
 );
 


### PR DESCRIPTION
## Checklist

- [ ] all tests passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Description of change
- Implements Base Chainbridge pallet for transferring assets from one chain to another.
- Dusty5 raw chain specification added to the configuration.

* * *
