### PR TITLE
Feature/dapps staking claim refactor

### DIFF
--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -69,6 +69,9 @@ pub struct EraStakingPoints<AccountId: Ord, Balance: HasCompact> {
     total: Balance,
     /// The map of stakers and the amount they staked.
     stakers: BTreeMap<AccountId, Balance>,
+    /// Era when this contract was staked last time before this one.
+    /// In case only a single staking era exists, it will be set to that one. This indicates the final element in the chain.
+    former_staked_era: EraIndex,
 }
 
 /// Multi-VM pointer to smart contract instance.

--- a/frame/dapps-staking/src/mock.rs
+++ b/frame/dapps-staking/src/mock.rs
@@ -181,8 +181,11 @@ pub fn advance_to_era(n: EraIndex) {
     }
 }
 
-/// adjust storage
-pub fn prepare_era_setup() {
+/// Initialize first block.
+/// This method should only be called once in a UT otherwise the first block will get initialized multiple times.
+pub fn initialize_first_block() {
+    // This assert prevents method misuse
+    assert_eq!(System::block_number(), 1 as BlockNumber);
     DappsStaking::on_initialize(System::block_number());
-    advance_to_era(2);
+    run_to_block(2);
 }

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -602,7 +602,6 @@ pub mod pallet {
                     break;
                 }
 
-
                 contract_staking_info = Self::contract_era_stake(&contract_id, &lower_bound_era)
                     .ok_or(Error::<T>::UnknownStartStakingData)?;
             }

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -591,7 +591,8 @@ pub mod pallet {
                         // This arm refers to situations where dev and staker are 'penalized' since they didn't collect rewards in time.
                         unclaimed_rewards += contract_reward_in_era;
                     }
-                }
+                } // end of one era interval iteration
+
                 upper_bound_era = lower_bound_era;
                 lower_bound_era = contract_staking_info.former_staked_era;
 
@@ -604,6 +605,7 @@ pub mod pallet {
 
                 contract_staking_info = Self::contract_era_stake(&contract_id, &lower_bound_era)
                     .ok_or(Error::<T>::UnknownStartStakingData)?;
+                // continue and process the next era interval
             }
 
             // send rewards to stakers

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -342,6 +342,7 @@ pub mod pallet {
                     EraStakingPoints {
                         total: Zero::zero(),
                         stakers: BTreeMap::<T::AccountId, BalanceOf<T>>::new(),
+                        former_staked_era: 0 as EraIndex,
                     }
                 };
 
@@ -379,6 +380,11 @@ pub mod pallet {
             Self::update_ledger(&staker, &ledger);
 
             // Update staked information for contract in current era
+            if let Some(last_staked_era) = era_when_contract_last_staked.clone() {
+                latest_era_staking_points.former_staked_era = last_staked_era;
+            } else {
+                latest_era_staking_points.former_staked_era = current_era;
+            }
             ContractEraStake::<T>::insert(
                 contract_id.clone(),
                 current_era,
@@ -464,6 +470,7 @@ pub mod pallet {
             }
             let value_to_unstake = value_to_unstake; // make it immutable
             era_staking_points.total = era_staking_points.total.saturating_sub(value_to_unstake);
+            era_staking_points.former_staked_era = era_when_contract_last_staked;
 
             // Get the staking ledger and update it
             let mut ledger = Self::ledger(&staker).ok_or(Error::<T>::UnexpectedState)?;
@@ -514,7 +521,8 @@ pub mod pallet {
                 .ok_or(Error::<T>::ContractNotRegistered)?;
 
             // check if it was ever staked on this contract.
-            Self::contract_last_staked(&contract_id).ok_or(Error::<T>::NothingToClaim)?;
+            let last_staked_era =
+                Self::contract_last_staked(&contract_id).ok_or(Error::<T>::NothingToClaim)?;
 
             // check if the contract is already claimed in this era
             let current_era = Self::current_era();
@@ -525,70 +533,93 @@ pub mod pallet {
                 Error::<T>::AlreadyClaimedInThisEra
             );
 
-            // oldest era to start with collecting rewards
+            // oldest era to start with collecting rewards for devs and stakers
             let last_allowed_era = current_era.saturating_sub(Self::history_depth());
-            let start_from_era = last_claim_era.max(last_allowed_era);
-            if start_from_era > last_claim_era {
-                // TODO collect all unclaimed rewards and send to Treasury pallet
-            }
 
-            // for the first claimable era "start_from_era", this storage item must be in place!
-            let mut contract_staking_info_prev =
-                Self::contract_era_stake(&contract_id, &start_from_era)
-                    .ok_or(Error::<T>::UnknownStartStakingData)?;
-
-            // initialize rewards for stakers and the developer
+            // initialize rewards for stakers, developer and unclaimed rewards accumulator
             let mut rewards_for_stakers_map: BTreeMap<T::AccountId, BalanceOf<T>> =
                 Default::default();
-            let mut reward_for_developer: BalanceOf<T> = Default::default();
+            let mut reward_for_developer: BalanceOf<T> = Zero::zero();
+            let mut unclaimed_rewards: BalanceOf<T> = Zero::zero();
 
-            // for any era after start_from_era, the ContractEraStake is present only if there
-            // was a change in staking amount. If it is not present we process last recorded ContractEraStake
-            for era in start_from_era..current_era {
-                let reward_and_stake_for_era =
-                    Self::era_reward_and_stake(era).ok_or(Error::<T>::UnknownEraReward)?;
-                let contract_staking_info = Self::contract_era_stake(&contract_id, era)
-                    .unwrap_or(contract_staking_info_prev);
+            // Next we iterate of periods between staking points.
+            // Since each era staking point struct has information about the former era when staking information
+            // was changed, we start from top and move to bottom.
+            // E.g.:
+            // [last_staked_era, current_era>,
+            // [last_staked_era.former_stake_era, last_staked_era>,
+            //  ...
 
-                // smallest unit of the reward in this era to use in calculation
-                let reward_particle = Perbill::from_rational(
-                    contract_staking_info.total,
-                    reward_and_stake_for_era.staked,
-                );
+            let mut lower_bound_era = last_staked_era;
+            let mut upper_bound_era = current_era;
+            let mut contract_staking_info =
+                Self::contract_era_stake(&contract_id, &lower_bound_era)
+                    .ok_or(Error::<T>::UnknownStartStakingData)?;
+            loop {
+                // accumulate rewards for this period
+                for era in lower_bound_era..upper_bound_era {
+                    let reward_and_stake_for_era =
+                        Self::era_reward_and_stake(era).ok_or(Error::<T>::UnknownEraReward)?;
 
-                // this contract's total reward in this era
-                let contract_reward_in_era = reward_particle * reward_and_stake_for_era.rewards;
+                    // Calculate the contract reward for this era.
+                    let reward_particle = Perbill::from_rational(
+                        contract_staking_info.total,
+                        reward_and_stake_for_era.staked,
+                    );
+                    let contract_reward_in_era = reward_particle * reward_and_stake_for_era.rewards;
 
-                // divide reward between stakers and the developer of the contract
-                let contract_staker_reward =
-                    Perbill::from_rational((100 - T::DeveloperRewardPercentage::get()) as u64, 100)
-                        * contract_reward_in_era;
-                let contract_developer_reward =
-                    Perbill::from_rational(T::DeveloperRewardPercentage::get() as u64, 100)
-                        * contract_reward_in_era;
+                    // First arm refers to situations where both dev and staker are eligible for rewards
+                    if era >= last_allowed_era {
+                        // divide reward between stakers and the developer of the contract
+                        let contract_staker_reward = Perbill::from_rational(
+                            (100 - T::DeveloperRewardPercentage::get()) as u64,
+                            100,
+                        ) * contract_reward_in_era;
+                        let contract_developer_reward =
+                            Perbill::from_rational(T::DeveloperRewardPercentage::get() as u64, 100)
+                                * contract_reward_in_era;
 
-                // accumulate rewards for the stakers
-                Self::stakers_era_reward(
-                    &mut rewards_for_stakers_map,
-                    &contract_staking_info,
-                    contract_staker_reward,
-                );
-                // accumulate rewards for the developer
-                reward_for_developer += contract_developer_reward;
+                        // accumulate rewards for the stakers
+                        Self::stakers_era_reward(
+                            &mut rewards_for_stakers_map,
+                            &contract_staking_info,
+                            contract_staker_reward,
+                        );
+                        // accumulate rewards for the developer
+                        reward_for_developer += contract_developer_reward;
+                    } else {
+                        // This arm refers to situations where dev and staker are 'penalized' since they didn't collect rewards in time.
+                        unclaimed_rewards += contract_reward_in_era;
+                    }
+                }
+                upper_bound_era = lower_bound_era;
+                lower_bound_era = contract_staking_info.former_staked_era;
 
-                // store current record in case next era has no record of changed stake amount
-                contract_staking_info_prev = contract_staking_info;
+                // Check if this is the last unprocessed era staking point. If it is, stop.
+                if lower_bound_era == upper_bound_era {
+                    // update struct so it reflects that it's the last known staking point value
+                    contract_staking_info.former_staked_era = current_era;
+                    break;
+                }
+
+
+                contract_staking_info = Self::contract_era_stake(&contract_id, &lower_bound_era)
+                    .ok_or(Error::<T>::UnknownStartStakingData)?;
             }
+
             // send rewards to stakers
             Self::payout_stakers(&rewards_for_stakers_map);
             // send rewards to developer
             T::Currency::deposit_into_existing(&developer, reward_for_developer).ok();
+            // if !unclaimed_rewards.is_zero() { TODO!
+            //     T::Currency::deposit_into_existing(&treasury, unclaimed_rewards).ok();
+            // }
 
             // Remove all previous records of staking for this contract,
             // they have already been processed and won't be needed anymore.
             ContractEraStake::<T>::remove_prefix(&contract_id, None);
             // create contract era stake data in current era for further staking and claiming
-            ContractEraStake::<T>::insert(&contract_id, current_era, contract_staking_info_prev);
+            ContractEraStake::<T>::insert(&contract_id, current_era, contract_staking_info);
 
             // move contract pointers to current era
             ContractLastClaimed::<T>::insert(&contract_id, current_era);
@@ -597,7 +628,7 @@ pub mod pallet {
             Self::deposit_event(Event::<T>::ContractClaimed(
                 contract_id,
                 claimer,
-                start_from_era,
+                last_claim_era.max(last_allowed_era),
                 current_era,
             ));
 

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -30,6 +30,19 @@ pub(crate) fn bond_and_stake_with_verification(
     ));
 }
 
+/// Used to perform unbond_unstake_and_withdraw with success assertion.
+pub(crate) fn unbond_unstake_and_withdraw_with_verification(
+    staker_id: AccountId,
+    contract_id: &SmartContract<AccountId>,
+    value: Balance,
+) {
+    assert_ok!(DappsStaking::unbond_unstake_and_withdraw(
+        Origin::signed(staker_id),
+        contract_id.clone(),
+        value,
+    ));
+}
+
 /// Used to verify ledger content.
 pub(crate) fn verify_ledger(staker_id: AccountId, staked_value: Balance) {
     // Verify that ledger storage values are as expected.
@@ -96,7 +109,8 @@ pub(crate) fn verify_contract_history_is_cleared(
     );
 
     // check new ContractEraStaked
-    assert!(mock::DappsStaking::contract_era_stake(contract, to_era).is_some());
+    let era_staking_points = mock::DappsStaking::contract_era_stake(contract, to_era).unwrap();
+    assert_eq!(era_staking_points.former_staked_era, to_era);
 
     // check history storage is cleared
     for era in from_era..to_era {

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -8,8 +8,7 @@ use testing_utils::*;
 #[test]
 fn bond_and_stake_different_eras_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let staker_id = 1;
         let first_stake_value = 100;
@@ -109,8 +108,7 @@ fn bond_and_stake_different_eras_is_ok() {
 #[test]
 fn bond_and_stake_two_different_contracts_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let staker_id = 1;
         let first_stake_value = 100;
@@ -157,8 +155,7 @@ fn bond_and_stake_two_different_contracts_is_ok() {
 #[test]
 fn bond_and_stake_two_stakers_one_contract_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let first_staker_id = 1;
         let second_staker_id = 2;
@@ -202,8 +199,7 @@ fn bond_and_stake_two_stakers_one_contract_is_ok() {
 #[test]
 fn bond_and_stake_different_value_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let staker_id = 1;
         let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
@@ -281,7 +277,8 @@ fn bond_and_stake_different_value_is_ok() {
 #[test]
 fn bond_and_stake_history_depth_has_passed_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
-        run_to_block(2);
+        initialize_first_block();
+
         let developer = 1;
         let staker_id = 2;
         let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
@@ -329,8 +326,7 @@ fn bond_and_stake_history_depth_has_passed_is_ok() {
 #[test]
 fn bond_and_stake_contract_is_not_ok() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let staker_id = 1;
         let stake_value = 100;
@@ -347,7 +343,7 @@ fn bond_and_stake_contract_is_not_ok() {
 #[test]
 fn bond_and_stake_insufficient_value() {
     ExternalityBuilder::build().execute_with(|| {
-        mock::prepare_era_setup();
+        initialize_first_block();
         let staker_id = 1;
         let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
 
@@ -383,8 +379,7 @@ fn bond_and_stake_insufficient_value() {
 #[test]
 fn bond_and_stake_too_many_stakers_per_contract() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
         // Insert a contract under registered contracts.
@@ -414,8 +409,7 @@ fn bond_and_stake_too_many_stakers_per_contract() {
 #[test]
 fn unbond_unstake_and_withdraw_multiple_time_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let staker_id = 1;
         let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
@@ -501,8 +495,7 @@ fn unbond_unstake_and_withdraw_multiple_time_is_ok() {
 #[test]
 fn unbond_unstake_and_withdraw_value_below_staking_threshold() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let staker_id = 1;
         let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
@@ -548,8 +541,7 @@ fn unbond_unstake_and_withdraw_value_below_staking_threshold() {
 #[test]
 fn unbond_unstake_and_withdraw_in_different_eras() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let first_staker_id = 1;
         let second_staker_id = 2;
@@ -635,7 +627,8 @@ fn unbond_unstake_and_withdraw_in_different_eras() {
 #[test]
 fn unbond_unstake_and_withdraw_history_depth_has_passed_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
-        run_to_block(2);
+        initialize_first_block();
+
         let developer = 1;
         let staker_id = 2;
         let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
@@ -733,8 +726,7 @@ fn unbond_unstake_and_withdraw_history_depth_has_passed_is_ok() {
 #[test]
 fn unbond_unstake_and_withdraw_contract_is_not_ok() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let staker_id = 1;
         let unstake_value = 100;
@@ -751,8 +743,7 @@ fn unbond_unstake_and_withdraw_contract_is_not_ok() {
 #[test]
 fn unbond_unstake_and_withdraw_unstake_not_possible() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let first_staker_id = 1;
         let first_contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
@@ -821,8 +812,7 @@ fn unbond_unstake_and_withdraw_unstake_not_possible() {
 #[test]
 fn register_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let developer = 1;
         let ok_contract = SmartContract::Evm(H160::repeat_byte(0x01));
@@ -838,8 +828,7 @@ fn register_is_ok() {
 #[test]
 fn register_twice_with_same_account_nok() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let developer = 1;
         let contract1 = SmartContract::Evm(H160::repeat_byte(0x01));
@@ -862,8 +851,7 @@ fn register_twice_with_same_account_nok() {
 #[test]
 fn register_same_contract_twice_nok() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let developer1 = 1;
         let developer2 = 2;
@@ -961,8 +949,7 @@ fn new_era_forcing() {
 #[test]
 fn claim_contract_not_registered() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let claimer = 2;
         let contract = SmartContract::Evm(H160::repeat_byte(0x01));
@@ -977,8 +964,7 @@ fn claim_contract_not_registered() {
 #[test]
 fn claim_nothing_to_claim() {
     ExternalityBuilder::build().execute_with(|| {
-        // prepare initial era
-        mock::prepare_era_setup();
+        initialize_first_block();
 
         let developer1 = 1;
         let claimer = 2;
@@ -996,12 +982,12 @@ fn claim_nothing_to_claim() {
 #[test]
 fn claim_twice_in_same_era() {
     ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
         let developer = 1;
         let claimer = 2;
         let contract = SmartContract::Evm(H160::repeat_byte(0x01));
 
-        // prepare initial era
-        mock::prepare_era_setup();
         let start_era = DappsStaking::current_era();
 
         register_contract(developer, &contract);
@@ -1022,7 +1008,8 @@ fn claim_twice_in_same_era() {
 #[test]
 fn claim_after_history_depth_has_passed_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
-        run_to_block(2);
+        initialize_first_block();
+
         let developer = 1;
         let claimer = 2;
         let contract = SmartContract::Evm(H160::repeat_byte(0x01));
@@ -1046,13 +1033,13 @@ fn claim_after_history_depth_has_passed_is_ok() {
 #[test]
 fn claim_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
         let developer = 1;
         let claimer = 2;
         let contract = SmartContract::Evm(H160::repeat_byte(0x01));
         const SKIP_ERA: EraIndex = 3;
 
-        // prepare initial era
-        mock::prepare_era_setup();
         let start_era = DappsStaking::current_era();
 
         register_contract(developer, &contract);
@@ -1069,6 +1056,8 @@ fn claim_is_ok() {
 #[test]
 fn claim_one_contract_one_staker() {
     ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
         let developer = 1;
         let staker1 = 2;
 
@@ -1081,9 +1070,6 @@ fn claim_one_contract_one_staker() {
         let free_balance_staker1 = <mock::TestRuntime as Config>::Currency::free_balance(&staker1);
         let free_developer_balance =
             <mock::TestRuntime as Config>::Currency::free_balance(&developer);
-
-        // prepare initial era
-        mock::prepare_era_setup();
 
         // Register contracts, bond&stake them with two stakers on the contract.
         let start_era = DappsStaking::current_era();
@@ -1124,6 +1110,8 @@ fn claim_one_contract_one_staker() {
 #[test]
 fn claim_one_contract_two_stakers() {
     ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
         let developer = 1;
         let staker1 = 2;
         let staker2 = 3;
@@ -1139,9 +1127,6 @@ fn claim_one_contract_two_stakers() {
         let free_balance_staker2 = <mock::TestRuntime as Config>::Currency::free_balance(&staker2);
         let free_developer_balance =
             <mock::TestRuntime as Config>::Currency::free_balance(&developer);
-
-        // prepare initial era
-        mock::prepare_era_setup();
 
         // Register contracts, bond&stake them with two stakers on the contract.
         let start_era = DappsStaking::current_era();
@@ -1208,6 +1193,8 @@ fn claim_one_contract_two_stakers() {
 #[test]
 fn claim_two_contracts_three_stakers() {
     ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
         let developer1 = 1;
         let developer2 = 10;
         let staker1: mock::AccountId = 2;
@@ -1233,9 +1220,6 @@ fn claim_two_contracts_three_stakers() {
             <mock::TestRuntime as Config>::Currency::free_balance(&developer1);
         let free_balance_developer2 =
             <mock::TestRuntime as Config>::Currency::free_balance(&developer2);
-
-        // prepare initial era
-        mock::prepare_era_setup();
 
         // Register 2 contracts, bond&stake with two stakers on first contract.
         // era=2


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./.github/CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] all tests passes
- [x] tests and/or benchmarks are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

## Affected core subsystem(s)
Dapps staking

## Description of change
Refactored claim so it works when the last staked contract era exceeds the history depth.

The new algorithm should decrease the number of required storage reads since it introduces
a 'former staking era' index to the era staking points struct.
This allows to break up staking intervals into intervals which can easily be processed. E.g.:
            [last_staked_era, current_era>,
            [last_staked_era.former_stake_era, last_staked_era>,
            ...
* * *
