### PR TITLE
registration with pre-approved list of contracts

### DIFF
--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -245,7 +245,7 @@ pub mod pallet {
         /// Contract already claimed in this era and reward is distributed
         AlreadyClaimedInThisEra,
         /// To register a contract, pre-approval is needed for this address
-        RequiredContractPreAproval,
+        RequiredContractPreApproval,
         /// Contract is already part of pre-apprved list of contracts
         AlreadyPreApprovedContract,
     }
@@ -310,7 +310,7 @@ pub mod pallet {
                 Self::pre_approved_contracts()
                     .contains(&contract_id)
                     .then(|| true)
-                    .ok_or(Error::<T>::RequiredContractPreAproval)?;
+                    .ok_or(Error::<T>::RequiredContractPreApproval)?;
             }
             RegisteredDapps::<T>::insert(contract_id.clone(), developer.clone());
             RegisteredDevelopers::<T>::insert(&developer, contract_id.clone());
@@ -320,7 +320,7 @@ pub mod pallet {
             Ok(().into())
         }
 
-        /// add contract address to the preaproved list.
+        /// add contract address to the pre-approved list.
         /// contract_id should be ink! or evm contract.
         ///
         /// Sudo call is required
@@ -335,13 +335,12 @@ pub mod pallet {
                 Error::<T>::AlreadyRegisteredContract
             );
 
-            let mut pre_approved_contracts = Self::pre_approved_contracts();
+            let pre_approved_contracts = Self::pre_approved_contracts();
             ensure!(
                 !pre_approved_contracts.contains(&contract_id),
                 Error::<T>::AlreadyPreApprovedContract
             );
-            pre_approved_contracts.push(contract_id);
-            PreApprovedContracts::<T>::put(pre_approved_contracts);
+            PreApprovedContracts::<T>::append(contract_id);
 
             Ok(().into())
         }
@@ -350,7 +349,7 @@ pub mod pallet {
         ///
         /// Sudo call is required
         #[pallet::weight(1_000_000)]
-        pub fn preaproval_for_new_contact_enabled(
+        pub fn enable_contract_preapproval(
             origin: OriginFor<T>,
             enabled: bool,
         ) -> DispatchResultWithPostInfo {

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -156,6 +156,21 @@ pub mod pallet {
     pub(crate) type ContractLastStaked<T: Config> =
         StorageMap<_, Twox64Concat, SmartContract<T::AccountId>, EraIndex>;
 
+    #[pallet::type_value]
+    pub(crate) fn PreApprovalOnEmpty() -> bool {
+        false
+    }
+    /// Enable or disable pre-approval list for new contract registration
+    #[pallet::storage]
+    #[pallet::getter(fn pre_approval_is_enabled)]
+    pub(crate) type PreApprovalIsEnabled<T> = StorageValue<_, bool, ValueQuery, PreApprovalOnEmpty>;
+
+    /// List of pre-approved contracts
+    #[pallet::storage]
+    #[pallet::getter(fn pre_approved_contracts)]
+    pub(crate) type PreApprovedContracts<T: Config> =
+        StorageValue<_, Vec<SmartContract<T::AccountId>>, ValueQuery>;
+
     // Declare the genesis config (optional).
     //
     // The macro accepts either a struct or an enum; it checks that generics are consistent.
@@ -229,6 +244,10 @@ pub mod pallet {
         NothingToClaim,
         /// Contract already claimed in this era and reward is distributed
         AlreadyClaimedInThisEra,
+        /// To register a contract, pre-approval is needed for this address
+        RequiredContractPreAproval,
+        /// Contract is already part of pre-apprved list of contracts
+        AlreadyPreApprovedContract,
     }
 
     #[pallet::hooks]
@@ -287,10 +306,56 @@ pub mod pallet {
                 Error::<T>::ContractIsNotValid
             );
 
+            if Self::pre_approval_is_enabled() {
+                Self::pre_approved_contracts()
+                    .contains(&contract_id)
+                    .then(|| true)
+                    .ok_or(Error::<T>::RequiredContractPreAproval)?;
+            }
             RegisteredDapps::<T>::insert(contract_id.clone(), developer.clone());
             RegisteredDevelopers::<T>::insert(&developer, contract_id.clone());
 
             Self::deposit_event(Event::<T>::NewContract(developer, contract_id));
+
+            Ok(().into())
+        }
+
+        /// add contract address to the preaproved list.
+        /// contract_id should be ink! or evm contract.
+        ///
+        /// Sudo call is required
+        #[pallet::weight(1_000_000)]
+        pub fn contract_pre_approval(
+            origin: OriginFor<T>,
+            contract_id: SmartContract<T::AccountId>,
+        ) -> DispatchResultWithPostInfo {
+            ensure_root(origin)?;
+            ensure!(
+                !RegisteredDapps::<T>::contains_key(&contract_id),
+                Error::<T>::AlreadyRegisteredContract
+            );
+
+            let mut pre_approved_contracts = Self::pre_approved_contracts();
+            ensure!(
+                !pre_approved_contracts.contains(&contract_id),
+                Error::<T>::AlreadyPreApprovedContract
+            );
+            pre_approved_contracts.push(contract_id);
+            PreApprovedContracts::<T>::put(pre_approved_contracts);
+
+            Ok(().into())
+        }
+
+        /// Enable or disable adding new contracts to the pre-approved list
+        ///
+        /// Sudo call is required
+        #[pallet::weight(1_000_000)]
+        pub fn preaproval_for_new_contact_enabled(
+            origin: OriginFor<T>,
+            enabled: bool,
+        ) -> DispatchResultWithPostInfo {
+            ensure_root(origin)?;
+            PreApprovalIsEnabled::<T>::put(enabled);
 
             Ok(().into())
         }

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -6,7 +6,7 @@ use sp_runtime::Perbill;
 
 /// Used to register contract for staking and assert success.
 pub(crate) fn register_contract(developer: AccountId, contract: &SmartContract<AccountId>) {
-    assert_ok!(mock::DappsStaking::preaproval_for_new_contact_enabled(
+    assert_ok!(mock::DappsStaking::enable_contract_preapproval(
         Origin::root(),
         false
     ));

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -6,6 +6,10 @@ use sp_runtime::Perbill;
 
 /// Used to register contract for staking and assert success.
 pub(crate) fn register_contract(developer: AccountId, contract: &SmartContract<AccountId>) {
+    assert_ok!(mock::DappsStaking::preaproval_for_new_contact_enabled(
+        Origin::root(),
+        false
+    ));
     assert_ok!(DappsStaking::register(
         Origin::signed(developer),
         contract.clone()

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -911,8 +911,7 @@ fn register_with_pre_aprove_enabled() {
             contract.clone()
         ));
         System::assert_last_event(mock::Event::DappsStaking(Event::NewContract(
-            developer,
-            contract,
+            developer, contract,
         )));
 
         // disable pre_approval and register contract2
@@ -922,10 +921,12 @@ fn register_with_pre_aprove_enabled() {
             Origin::root(),
             false
         ));
-        assert_ok!(DappsStaking::register(Origin::signed(developer2), contract2.clone()));
+        assert_ok!(DappsStaking::register(
+            Origin::signed(developer2),
+            contract2.clone()
+        ));
         System::assert_last_event(mock::Event::DappsStaking(Event::NewContract(
-            developer2,
-            contract2,
+            developer2, contract2,
         )));
     })
 }

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -874,14 +874,14 @@ fn register_same_contract_twice_nok() {
 }
 
 #[test]
-fn register_with_pre_aprove_enabled() {
+fn register_with_pre_approve_enabled() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();
         let developer = 1;
         let contract = SmartContract::Evm(H160::repeat_byte(0x01));
 
         // enable pre-approval of the contracts
-        assert_ok!(mock::DappsStaking::preaproval_for_new_contact_enabled(
+        assert_ok!(mock::DappsStaking::enable_contract_preapproval(
             Origin::root(),
             true
         ));
@@ -890,7 +890,7 @@ fn register_with_pre_aprove_enabled() {
         // register new contract without pre-aproval should fail
         assert_noop!(
             DappsStaking::register(Origin::signed(developer), contract.clone()),
-            Error::<TestRuntime>::RequiredContractPreAproval
+            Error::<TestRuntime>::RequiredContractPreApproval
         );
 
         // preapprove contract
@@ -899,13 +899,13 @@ fn register_with_pre_aprove_enabled() {
             contract.clone()
         ));
 
-        // try to preaprove again same contract, should fail
+        // try to pre-approve again same contract, should fail
         assert_noop!(
             mock::DappsStaking::contract_pre_approval(Origin::root(), contract.clone()),
             Error::<TestRuntime>::AlreadyPreApprovedContract
         );
 
-        // register new contract which is pre-aproved
+        // register new contract which is pre-approved
         assert_ok!(DappsStaking::register(
             Origin::signed(developer),
             contract.clone()
@@ -917,7 +917,7 @@ fn register_with_pre_aprove_enabled() {
         // disable pre_approval and register contract2
         let developer2 = 2;
         let contract2 = SmartContract::Evm(H160::repeat_byte(0x02));
-        assert_ok!(mock::DappsStaking::preaproval_for_new_contact_enabled(
+        assert_ok!(mock::DappsStaking::enable_contract_preapproval(
             Origin::root(),
             false
         ));

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -874,6 +874,63 @@ fn register_same_contract_twice_nok() {
 }
 
 #[test]
+fn register_with_pre_aprove_enabled() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+        let developer = 1;
+        let contract = SmartContract::Evm(H160::repeat_byte(0x01));
+
+        // enable pre-approval of the contracts
+        assert_ok!(mock::DappsStaking::preaproval_for_new_contact_enabled(
+            Origin::root(),
+            true
+        ));
+        assert!(mock::DappsStaking::pre_approval_is_enabled());
+
+        // register new contract without pre-aproval should fail
+        assert_noop!(
+            DappsStaking::register(Origin::signed(developer), contract.clone()),
+            Error::<TestRuntime>::RequiredContractPreAproval
+        );
+
+        // preapprove contract
+        assert_ok!(mock::DappsStaking::contract_pre_approval(
+            Origin::root(),
+            contract.clone()
+        ));
+
+        // try to preaprove again same contract, should fail
+        assert_noop!(
+            mock::DappsStaking::contract_pre_approval(Origin::root(), contract.clone()),
+            Error::<TestRuntime>::AlreadyPreApprovedContract
+        );
+
+        // register new contract which is pre-aproved
+        assert_ok!(DappsStaking::register(
+            Origin::signed(developer),
+            contract.clone()
+        ));
+        System::assert_last_event(mock::Event::DappsStaking(Event::NewContract(
+            developer,
+            contract,
+        )));
+
+        // disable pre_approval and register contract2
+        let developer2 = 2;
+        let contract2 = SmartContract::Evm(H160::repeat_byte(0x02));
+        assert_ok!(mock::DappsStaking::preaproval_for_new_contact_enabled(
+            Origin::root(),
+            false
+        ));
+        assert_ok!(DappsStaking::register(Origin::signed(developer2), contract2.clone()));
+        System::assert_last_event(mock::Event::DappsStaking(Event::NewContract(
+            developer2,
+            contract2,
+        )));
+    })
+}
+
+#[test]
 fn new_era_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
         // set initial era index


### PR DESCRIPTION
Implement pre-approved list for dApps contract registration

- [x] Enable/Disable pre-approved entry. If enabled, registration is possible only if contract's address is listed
- [x] create storage entry for pre-approved contract addresses
- [x] extrinsic sudo fn to add an address to the pre-approved list
- [x] extrinsic sudo fn to enable/disable pre-approving contracts
- [x] all tests passes

