### PR TITLE
SmartContract as trait

### DIFF
--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -10,7 +10,9 @@ use sp_runtime::RuntimeDebug;
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
 pub mod pallet;
+pub mod traits;
 pub mod weights;
+pub use traits::*;
 
 #[cfg(test)]
 mod mock;
@@ -74,13 +76,4 @@ pub struct EraStakingPoints<AccountId: Ord, Balance: HasCompact> {
     former_staked_era: EraIndex,
     /// Accrued and claimed rewards on this contract both for stakers and the developer
     claimed_rewards: Balance,
-}
-
-/// Multi-VM pointer to smart contract instance.
-#[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, RuntimeDebug)]
-pub enum SmartContract<AccountId> {
-    /// EVM smart contract instance.
-    Evm(sp_core::H160),
-    /// Wasm smart contract instance.
-    Wasm(AccountId),
 }

--- a/frame/dapps-staking/src/mock.rs
+++ b/frame/dapps-staking/src/mock.rs
@@ -136,7 +136,7 @@ pub enum MockSmartContract<AccountId> {
     Wasm(AccountId),
 }
 
-impl<AccountId> pallet_dapps_staking::IsContract<AccountId> for MockSmartContract<AccountId> {
+impl<AccountId> pallet_dapps_staking::IsContract for MockSmartContract<AccountId> {
     fn is_contract(&self) -> bool {
         match self {
             MockSmartContract::Wasm(_account) => false,

--- a/frame/dapps-staking/src/mock.rs
+++ b/frame/dapps-staking/src/mock.rs
@@ -124,10 +124,25 @@ impl pallet_dapps_staking::Config for TestRuntime {
     type BlockPerEra = BlockPerEra;
     type RegisterDeposit = RegisterDeposit;
     type DeveloperRewardPercentage = DeveloperRewardPercentage;
+    type SmartContract = MockSmartContract<AccountId>;
     type WeightInfo = ();
     type MaxNumberOfStakersPerContract = MaxNumberOfStakersPerContract;
     type MinimumStakingAmount = MinimumStakingAmount;
     type PalletId = DappsStakingPalletId;
+}
+
+pub enum MockSmartContract<AccountId> {
+    Evm(sp_core::H160),
+    Wasm(AccountId),
+}
+
+impl<AccountId> pallet_dapps_staking::IsContract<AccountId> for MockSmartContract<AccountId> {
+    fn is_contract(&self) -> bool {
+        match self {
+            MockSmartContract::Wasm(_account) => false,
+            MockSmartContract::Evm(_account) => true,
+        }
+    }
 }
 
 pub struct ExternalityBuilder;

--- a/frame/dapps-staking/src/mock.rs
+++ b/frame/dapps-staking/src/mock.rs
@@ -7,6 +7,7 @@ use frame_support::{
 };
 use sp_core::H256;
 
+use codec::{Decode, Encode};
 use sp_io::TestExternalities;
 use sp_runtime::{
     testing::Header,
@@ -131,6 +132,7 @@ impl pallet_dapps_staking::Config for TestRuntime {
     type PalletId = DappsStakingPalletId;
 }
 
+#[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, Debug)]
 pub enum MockSmartContract<AccountId> {
     Evm(sp_core::H160),
     Wasm(AccountId),

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -54,6 +54,9 @@ pub mod pallet {
         type Currency: LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>
             + ReservableCurrency<Self::AccountId>;
 
+        // type used for Accounts on EVM and on Substrate
+        type SmartContract: IsContract<Self::AccountId>;
+
         /// Number of blocks per era.
         #[pallet::constant]
         type BlockPerEra: Get<BlockNumberFor<Self>>;
@@ -321,7 +324,7 @@ pub mod pallet {
                 Error::<T>::AlreadyRegisteredContract
             );
             ensure!(
-                Self::is_contract_valid(&contract_id),
+                SmartContract::is_contract(&contract_id),
                 Error::<T>::ContractIsNotValid
             );
 
@@ -811,20 +814,6 @@ pub mod pallet {
             } else {
                 T::Currency::set_lock(STAKING_ID, &staker, ledger.clone(), WithdrawReasons::all());
                 Ledger::<T>::insert(staker, ledger);
-            }
-        }
-
-        /// Checks if there is a valid smart contract for the provided address
-        fn is_contract_valid(address: &SmartContract<T::AccountId>) -> bool {
-            match address {
-                SmartContract::Wasm(_account) => {
-                    //     <pallet_contracts::ContractInfoOf<T>>::get(&account).is_some()
-                    false
-                }
-                SmartContract::Evm(_account) => {
-                    // pallet_evm::Module::<T>::account_codes(&account).len() > 0 TODO remove comment after EVM mege
-                    true
-                }
             }
         }
 

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -137,7 +137,7 @@ pub mod pallet {
     pub(crate) type RegisteredDapps<T: Config> =
         StorageMap<_, Twox64Concat, T::SmartContract, T::AccountId>;
 
-    /// Total block rewards for the pallet per era
+    /// Total block rewards for the pallet per era and total staked funds
     #[pallet::storage]
     #[pallet::getter(fn era_reward_and_stake)]
     pub(crate) type EraRewardsAndStakes<T: Config> =
@@ -220,11 +220,11 @@ pub mod pallet {
         BondAndStake(T::AccountId, T::SmartContract, BalanceOf<T>),
         /// Account has unbonded, unstaked and withdrawn funds.
         UnbondUnstakeAndWithdraw(T::AccountId, T::SmartContract, BalanceOf<T>),
-        /// New contract added for staking, with deposit value
+        /// New contract added for staking.
         NewContract(T::AccountId, T::SmartContract),
-        /// New dapps staking era. Distribute era rewards to contracts
+        /// New dapps staking era. Distribute era rewards to contracts.
         NewDappStakingEra(EraIndex),
-        /// The contract's reward have been claimed, by an account, from era, until era
+        /// The contract's reward have been claimed, by an account, from era, until era.
         ContractClaimed(T::SmartContract, T::AccountId, EraIndex, EraIndex),
     }
 

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -91,7 +91,7 @@ pub mod pallet {
 
     #[pallet::type_value]
     pub(crate) fn HistoryDepthOnEmpty() -> u32 {
-        84u32
+        30u32
     }
 
     /// Bonded amount for the staker

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -55,7 +55,7 @@ pub mod pallet {
             + ReservableCurrency<Self::AccountId>;
 
         // type used for Accounts on EVM and on Substrate
-        type SmartContract: IsContract<Self::AccountId>;
+        type SmartContract: IsContract;
 
         /// Number of blocks per era.
         #[pallet::constant]
@@ -323,10 +323,7 @@ pub mod pallet {
                 !RegisteredDapps::<T>::contains_key(&contract_id),
                 Error::<T>::AlreadyRegisteredContract
             );
-            ensure!(
-                SmartContract::is_contract(&contract_id),
-                Error::<T>::ContractIsNotValid
-            );
+            ensure!(contract_id.is_contract(), Error::<T>::ContractIsNotValid);
 
             if Self::pre_approval_is_enabled() {
                 Self::pre_approved_contracts()

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -61,7 +61,6 @@ pub mod pallet {
         #[pallet::constant]
         type BlockPerEra: Get<BlockNumberFor<Self>>;
 
-        // TODO: this should be used?
         /// Minimum bonded deposit for new contract registration.
         #[pallet::constant]
         type RegisterDeposit: Get<BalanceOf<Self>>;
@@ -249,9 +248,6 @@ pub mod pallet {
         ContractIsNotValid,
         /// Claiming contract with no developer account
         ContractNotRegistered,
-        // TODO: make use of this?
-        /// Missing deposit for the contract registration
-        InsufficientDeposit,
         /// This account was already used to register contract
         AlreadyUsedDeveloperAccount,
         /// Unexpected state error, used to abort transaction. Used for situations that 'should never happen'.
@@ -727,40 +723,11 @@ pub mod pallet {
             Ok(().into())
         }
 
-        // =============== Era ==================
-
-        /// Force there to be no new eras indefinitely.
-        ///
-        /// The dispatch origin must be Root.
-        ///
-        /// # Warning
-        ///
-        /// The election process starts multiple blocks before the end of the era.
-        /// Thus the election process may be ongoing when this is called. In this case the
-        /// election will continue until the next era is triggered.
-        ///
-        /// # <weight>
-        /// - No arguments.
-        /// - Weight: O(1)
-        /// - Write: ForceEra
-        /// # </weight>
-        #[pallet::weight(T::WeightInfo::force_no_eras())]
-        pub fn force_no_eras(origin: OriginFor<T>) -> DispatchResult {
-            ensure_root(origin)?;
-            ForceEra::<T>::put(Forcing::ForceNone);
-            Ok(())
-        }
-
-        /// Force there to be a new era at the end of the next session. After this, it will be
+        /// Force there to be a new era at the end of the next block. After this, it will be
         /// reset to normal (non-forced) behaviour.
         ///
         /// The dispatch origin must be Root.
         ///
-        /// # Warning
-        ///
-        /// The election process starts multiple blocks before the end of the era.
-        /// If this is called just before a new era is triggered, the election process may not
-        /// have enough blocks to get a result.
         ///
         /// # <weight>
         /// - No arguments.
@@ -771,27 +738,6 @@ pub mod pallet {
         pub fn force_new_era(origin: OriginFor<T>) -> DispatchResult {
             ensure_root(origin)?;
             ForceEra::<T>::put(Forcing::ForceNew);
-            Ok(())
-        }
-
-        /// Force there to be a new era at the end of blocks indefinitely.
-        ///
-        /// The dispatch origin must be Root.
-        ///
-        /// # Warning
-        ///
-        /// The election process starts multiple blocks before the end of the era.
-        /// If this is called just before a new era is triggered, the election process may not
-        /// have enough blocks to get a result.
-        ///
-        /// # <weight>
-        /// - Weight: O(1)
-        /// - Write: ForceEra
-        /// # </weight>
-        #[pallet::weight(T::WeightInfo::force_new_era_always())]
-        pub fn force_new_era_always(origin: OriginFor<T>) -> DispatchResult {
-            ensure_root(origin)?;
-            ForceEra::<T>::put(Forcing::ForceAlways);
             Ok(())
         }
     }

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -150,7 +150,7 @@ pub mod pallet {
     pub(crate) type RewardsClaimed<T: Config> = StorageDoubleMap<
         _,
         Twox64Concat,
-        SmartContract<T::AccountId>,
+        T::SmartContract,
         Twox64Concat,
         T::AccountId,
         BalanceOf<T>,
@@ -826,7 +826,7 @@ pub mod pallet {
         /// Execute payout for stakers.
         /// Return total rewards claimed by stakers on this contract.
         fn payout_stakers_and_get_total_reward(
-            contract: &SmartContract<T::AccountId>,
+            contract: &T::SmartContract,
             staker_map: &BTreeMap<T::AccountId, BalanceOf<T>>,
         ) -> BalanceOf<T> {
             let mut reward_for_stakers = Zero::zero();

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -5,7 +5,7 @@ use sp_runtime::traits::Zero;
 use sp_runtime::Perbill;
 
 /// Used to register contract for staking and assert success.
-pub(crate) fn register_contract(developer: AccountId, contract: &SmartContract<AccountId>) {
+pub(crate) fn register_contract(developer: AccountId, contract: &MockSmartContract<AccountId>) {
     assert_ok!(mock::DappsStaking::enable_contract_preapproval(
         Origin::root(),
         false
@@ -24,7 +24,7 @@ pub(crate) fn get_total_reward_per_era() -> Balance {
 /// Used to perform bond_and_stake with success assertion.
 pub(crate) fn bond_and_stake_with_verification(
     staker_id: AccountId,
-    contract_id: &SmartContract<AccountId>,
+    contract_id: &MockSmartContract<AccountId>,
     value: Balance,
 ) {
     assert_ok!(DappsStaking::bond_and_stake(
@@ -37,7 +37,7 @@ pub(crate) fn bond_and_stake_with_verification(
 /// Used to perform unbond_unstake_and_withdraw with success assertion.
 pub(crate) fn unbond_unstake_and_withdraw_with_verification(
     staker_id: AccountId,
-    contract_id: &SmartContract<AccountId>,
+    contract_id: &MockSmartContract<AccountId>,
     value: Balance,
 ) {
     assert_ok!(DappsStaking::unbond_unstake_and_withdraw(
@@ -56,7 +56,7 @@ pub(crate) fn verify_ledger(staker_id: AccountId, staked_value: Balance) {
 
 /// Used to verify era staking points content.
 pub(crate) fn verify_era_staking_points(
-    contract_id: &SmartContract<AccountId>,
+    contract_id: &MockSmartContract<AccountId>,
     total_staked_value: Balance,
     era: crate::EraIndex,
     stakers: Vec<(AccountId, Balance)>,
@@ -95,7 +95,7 @@ pub(crate) fn verify_pallet_era_staked_and_reward(
 
 /// Used to verify storage content after claim() is successfuly executed.
 pub(crate) fn verify_contract_history_is_cleared(
-    contract: SmartContract<mock::AccountId>,
+    contract: MockSmartContract<mock::AccountId>,
     from_era: EraIndex,
     to_era: EraIndex,
 ) {
@@ -124,7 +124,7 @@ pub(crate) fn verify_contract_history_is_cleared(
 /// Used to perform claim with success assertion
 pub(crate) fn claim(
     claimer: AccountId,
-    contract: SmartContract<mock::AccountId>,
+    contract: MockSmartContract<mock::AccountId>,
     start_era: EraIndex,
     claim_era: EraIndex,
 ) {

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -162,7 +162,7 @@ pub(crate) fn calc_expected_developer_reward(
 /// Check staker/dev Balance after reward distribution.
 /// Check that claimed rewards for staker/dev are updated.
 pub(crate) fn check_rewards_on_balance_and_storage(
-    contract: &SmartContract<mock::AccountId>,
+    contract: &MockSmartContract<mock::AccountId>,
     user: &AccountId,
     free_balance: mock::Balance,
     eras: EraIndex,
@@ -181,7 +181,7 @@ pub(crate) fn check_rewards_on_balance_and_storage(
 
 /// Check that claimed rewards on this contract are updated
 pub(crate) fn check_paidout_rewards_for_contract(
-    contract: &SmartContract<mock::AccountId>,
+    contract: &MockSmartContract<mock::AccountId>,
     expected_contract_reward: mock::Balance,
 ) {
     let era_last_claimed = mock::DappsStaking::contract_last_claimed(contract).unwrap_or(0);

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{pallet::pallet::Error, Event, *};
 use frame_support::{assert_noop, assert_ok};
-use mock::{Balances, EraIndex, *};
+use mock::{Balances, EraIndex, MockSmartContract, *};
 use sp_core::H160;
 use sp_runtime::traits::Zero;
 use testing_utils::*;
@@ -12,7 +12,7 @@ fn bond_and_stake_different_eras_is_ok() {
 
         let staker_id = 1;
         let first_stake_value = 100;
-        let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
 
         let current_era = DappsStaking::current_era();
 
@@ -113,8 +113,8 @@ fn bond_and_stake_two_different_contracts_is_ok() {
         let staker_id = 1;
         let first_stake_value = 100;
         let second_stake_value = 300;
-        let first_contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
-        let second_contract_id = SmartContract::Evm(H160::repeat_byte(0x02));
+        let first_contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+        let second_contract_id = MockSmartContract::Evm(H160::repeat_byte(0x02));
         let current_era = mock::DappsStaking::current_era();
 
         // Insert contracts under registered contracts. Don't use the staker Id.
@@ -161,7 +161,7 @@ fn bond_and_stake_two_stakers_one_contract_is_ok() {
         let second_staker_id = 2;
         let first_stake_value = 50;
         let second_stake_value = 235;
-        let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
         let current_era = mock::DappsStaking::current_era();
 
         // Insert a contract under registered contracts.
@@ -202,7 +202,7 @@ fn bond_and_stake_different_value_is_ok() {
         initialize_first_block();
 
         let staker_id = 1;
-        let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
 
         // Insert a contract under registered contracts.
         register_contract(20, &contract_id);
@@ -281,7 +281,7 @@ fn bond_and_stake_history_depth_has_passed_is_ok() {
 
         let developer = 1;
         let staker_id = 2;
-        let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
 
         let start_era = DappsStaking::current_era();
         register_contract(developer, &contract_id);
@@ -332,7 +332,7 @@ fn bond_and_stake_contract_is_not_ok() {
         let stake_value = 100;
 
         // Check not registered contract. Expect an error.
-        let evm_contract = SmartContract::Evm(H160::repeat_byte(0x01));
+        let evm_contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
         assert_noop!(
             DappsStaking::bond_and_stake(Origin::signed(staker_id), evm_contract, stake_value),
             Error::<TestRuntime>::NotOperatedContract
@@ -345,7 +345,7 @@ fn bond_and_stake_insufficient_value() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();
         let staker_id = 1;
-        let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
 
         // Insert a contract under registered contracts.
         register_contract(20, &contract_id);
@@ -381,7 +381,7 @@ fn bond_and_stake_too_many_stakers_per_contract() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();
 
-        let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
         // Insert a contract under registered contracts.
         register_contract(10, &contract_id);
 
@@ -412,7 +412,7 @@ fn unbond_unstake_and_withdraw_multiple_time_is_ok() {
         initialize_first_block();
 
         let staker_id = 1;
-        let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
         let original_staked_value = 300 + MINIMUM_STAKING_AMOUNT;
         let old_era = mock::DappsStaking::current_era();
 
@@ -498,7 +498,7 @@ fn unbond_unstake_and_withdraw_value_below_staking_threshold() {
         initialize_first_block();
 
         let staker_id = 1;
-        let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
         let first_value_to_unstake = 300;
         let staked_value = first_value_to_unstake + MINIMUM_STAKING_AMOUNT;
 
@@ -545,7 +545,7 @@ fn unbond_unstake_and_withdraw_in_different_eras() {
 
         let first_staker_id = 1;
         let second_staker_id = 2;
-        let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
         let staked_value = 500;
 
         // Insert a contract under registered contracts, bond&stake it with two different stakers.
@@ -631,7 +631,7 @@ fn unbond_unstake_and_withdraw_history_depth_has_passed_is_ok() {
 
         let developer = 1;
         let staker_id = 2;
-        let contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
 
         //////////////////////////////////////////////
         ///// FIRST ERA
@@ -732,7 +732,7 @@ fn unbond_unstake_and_withdraw_contract_is_not_ok() {
         let unstake_value = 100;
 
         // Contract isn't registered, expect an error.
-        let evm_contract = SmartContract::Evm(H160::repeat_byte(0x01));
+        let evm_contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
         assert_noop!(
             DappsStaking::bond_and_stake(Origin::signed(staker_id), evm_contract, unstake_value),
             Error::<TestRuntime>::NotOperatedContract
@@ -746,7 +746,7 @@ fn unbond_unstake_and_withdraw_unstake_not_possible() {
         initialize_first_block();
 
         let first_staker_id = 1;
-        let first_contract_id = SmartContract::Evm(H160::repeat_byte(0x01));
+        let first_contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
         let original_staked_value = 100 + MINIMUM_STAKING_AMOUNT;
 
         // Insert a contract under registered contracts, bond&stake it.
@@ -791,7 +791,7 @@ fn unbond_unstake_and_withdraw_unstake_not_possible() {
         );
 
         // Bond a second contract using the second staker. Ensure that second staker still cannot unbond&withdraw funds from the first contract
-        let second_contract_id = SmartContract::Evm(H160::repeat_byte(0x02));
+        let second_contract_id = MockSmartContract::Evm(H160::repeat_byte(0x02));
         register_contract(20, &second_contract_id);
         bond_and_stake_with_verification(
             second_staker_id,
@@ -815,7 +815,7 @@ fn register_is_ok() {
         initialize_first_block();
 
         let developer = 1;
-        let ok_contract = SmartContract::Evm(H160::repeat_byte(0x01));
+        let ok_contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
 
         register_contract(developer, &ok_contract);
         System::assert_last_event(mock::Event::DappsStaking(Event::NewContract(
@@ -831,8 +831,8 @@ fn register_twice_with_same_account_nok() {
         initialize_first_block();
 
         let developer = 1;
-        let contract1 = SmartContract::Evm(H160::repeat_byte(0x01));
-        let contract2 = SmartContract::Evm(H160::repeat_byte(0x02));
+        let contract1 = MockSmartContract::Evm(H160::repeat_byte(0x01));
+        let contract2 = MockSmartContract::Evm(H160::repeat_byte(0x02));
 
         register_contract(developer, &contract1);
 
@@ -855,7 +855,7 @@ fn register_same_contract_twice_nok() {
 
         let developer1 = 1;
         let developer2 = 2;
-        let contract = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
 
         register_contract(developer1, &contract);
 
@@ -878,7 +878,7 @@ fn register_with_pre_approve_enabled() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();
         let developer = 1;
-        let contract = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
 
         // enable pre-approval of the contracts
         assert_ok!(mock::DappsStaking::enable_contract_preapproval(
@@ -916,7 +916,7 @@ fn register_with_pre_approve_enabled() {
 
         // disable pre_approval and register contract2
         let developer2 = 2;
-        let contract2 = SmartContract::Evm(H160::repeat_byte(0x02));
+        let contract2 = MockSmartContract::Evm(H160::repeat_byte(0x02));
         assert_ok!(mock::DappsStaking::enable_contract_preapproval(
             Origin::root(),
             false
@@ -954,7 +954,7 @@ fn new_era_is_ok() {
         let staker = 2;
         let developer = 3;
         const STAKED_AMOUNT: Balance = 100;
-        let contract = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
         register_contract(developer, &contract);
         bond_and_stake_with_verification(staker, &contract, STAKED_AMOUNT);
 
@@ -1010,7 +1010,7 @@ fn claim_contract_not_registered() {
         initialize_first_block();
 
         let claimer = 2;
-        let contract = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
 
         assert_noop!(
             DappsStaking::claim(Origin::signed(claimer), contract),
@@ -1026,7 +1026,7 @@ fn claim_nothing_to_claim() {
 
         let developer1 = 1;
         let claimer = 2;
-        let contract = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
 
         register_contract(developer1, &contract);
 
@@ -1044,7 +1044,7 @@ fn claim_twice_in_same_era() {
 
         let developer = 1;
         let claimer = 2;
-        let contract = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
 
         let start_era = DappsStaking::current_era();
 
@@ -1070,7 +1070,7 @@ fn claim_after_history_depth_has_passed_is_ok() {
 
         let developer = 1;
         let claimer = 2;
-        let contract = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
 
         let start_era = DappsStaking::current_era();
         register_contract(developer, &contract);
@@ -1095,7 +1095,7 @@ fn claim_is_ok() {
 
         let developer = 1;
         let claimer = 2;
-        let contract = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
         const SKIP_ERA: EraIndex = 3;
 
         let start_era = DappsStaking::current_era();
@@ -1121,7 +1121,7 @@ fn claim_one_contract_one_staker() {
 
         const STAKE_AMOUNT1: mock::Balance = 1000;
         const INITIAL_STAKE: mock::Balance = 1000;
-        let contract = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
         const SKIP_ERA: EraIndex = 4;
 
         // Store initial free balaces of the developer and the stakers
@@ -1186,7 +1186,7 @@ fn claim_one_contract_two_stakers() {
         const STAKE_AMOUNT1: mock::Balance = 400;
         const STAKE_AMOUNT2: mock::Balance = 600;
         const INITIAL_STAKE: mock::Balance = 1000;
-        let contract = SmartContract::Evm(H160::repeat_byte(0x01));
+        let contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
         const SKIP_ERA: EraIndex = 2;
 
         // Store initial free balaces of the developer and the stakers
@@ -1287,8 +1287,8 @@ fn claim_two_contracts_three_stakers() {
         const CONTRACT2_STAKE: mock::Balance = 500;
         const ERA_STAKED1: mock::Balance = 1000; // 400 + 600
         const ERA_STAKED2: mock::Balance = 1500; // 1000 + 100 + 400
-        let contract1 = SmartContract::Evm(H160::repeat_byte(0x01));
-        let contract2 = SmartContract::Evm(H160::repeat_byte(0x02));
+        let contract1 = MockSmartContract::Evm(H160::repeat_byte(0x01));
+        let contract2 = MockSmartContract::Evm(H160::repeat_byte(0x02));
         const SKIP_ERA: EraIndex = 3;
 
         // Store initial free balaces of developers and stakers

--- a/frame/dapps-staking/src/traits.rs
+++ b/frame/dapps-staking/src/traits.rs
@@ -9,6 +9,6 @@ pub enum SmartContract<AccountId> {
     Wasm(AccountId),
 }
 
-pub trait IsContract<AccountId> {
+pub trait IsContract {
     fn is_contract(&self) -> bool;
 }

--- a/frame/dapps-staking/src/traits.rs
+++ b/frame/dapps-staking/src/traits.rs
@@ -1,0 +1,14 @@
+use super::*;
+
+/// Multi-VM pointer to smart contract instance.
+#[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, RuntimeDebug)]
+pub enum SmartContract<AccountId> {
+    /// EVM smart contract instance.
+    Evm(sp_core::H160),
+    /// Wasm smart contract instance.
+    Wasm(AccountId),
+}
+
+pub trait IsContract<AccountId> {
+    fn is_contract(&self) -> bool;
+}

--- a/frame/dapps-staking/src/traits.rs
+++ b/frame/dapps-staking/src/traits.rs
@@ -1,14 +1,3 @@
-use super::*;
-
-/// Multi-VM pointer to smart contract instance.
-#[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, RuntimeDebug)]
-pub enum SmartContract<AccountId> {
-    /// EVM smart contract instance.
-    Evm(sp_core::H160),
-    /// Wasm smart contract instance.
-    Wasm(AccountId),
-}
-
 pub trait IsContract {
     fn is_contract(&self) -> bool;
 }

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -301,6 +301,16 @@ impl pallet_dapps_staking::Config for Runtime {
     type PalletId = DappsStakingPalletId;
 }
 
+/// Multi-VM pointer to smart contract instance.
+use codec::{Decode, Encode};
+#[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, RuntimeDebug)]
+pub enum SmartContract<AccountId> {
+    /// EVM smart contract instance.
+    Evm(sp_core::H160),
+    /// Wasm smart contract instance.
+    Wasm(AccountId),
+}
+
 impl<AccountId> IsContract for SmartContract<AccountId> {
     fn is_contract(&self) -> bool {
         match self {

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -283,7 +283,7 @@ impl pallet_block_reward::Config for Runtime {
 
 parameter_types! {
     pub const BlockPerEra: BlockNumber = 60;
-    pub const RegisterDeposit: Balance = 100;
+    pub const RegisterDeposit: Balance = 100 * AST;
     pub const DeveloperRewardPercentage: u32 = 80;
     pub const MaxNumberOfStakersPerContract: u32 = 128;
     pub const MinimumStakingAmount: Balance = 10;

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -301,13 +301,11 @@ impl pallet_dapps_staking::Config for Runtime {
     type PalletId = DappsStakingPalletId;
 }
 
-impl<AccountId> IsContract<AccountId> for SmartContract<AccountId> {
+impl<AccountId> IsContract for SmartContract<AccountId> {
     fn is_contract(&self) -> bool {
         match self {
             SmartContract::Wasm(_account) => false,
-            SmartContract::Evm(account) => {
-                EVM::account_codes(&account).len() > 0
-            }
+            SmartContract::Evm(account) => EVM::account_codes(&account).len() > 0,
         }
     }
 }

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -291,6 +291,7 @@ parameter_types! {
 impl pallet_dapps_staking::Config for Runtime {
     type Currency = Balances;
     type BlockPerEra = BlockPerEra;
+    type SmartContract = SmartContract<AccountId>;
     type RegisterDeposit = RegisterDeposit;
     type DeveloperRewardPercentage = DeveloperRewardPercentage;
     type Event = Event;
@@ -298,6 +299,17 @@ impl pallet_dapps_staking::Config for Runtime {
     type MaxNumberOfStakersPerContract = MaxNumberOfStakersPerContract;
     type MinimumStakingAmount = MinimumStakingAmount;
     type PalletId = DappsStakingPalletId;
+}
+
+impl<AccountId> IsContract<AccountId> for SmartContract<AccountId> {
+    fn is_contract(&self) -> bool {
+        match self {
+            SmartContract::Wasm(_account) => false,
+            SmartContract::Evm(account) => {
+                EVM::account_codes(&account).len() > 0
+            }
+        }
+    }
 }
 
 /// Current approximation of the gas/s consumption considering

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -2,6 +2,7 @@
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
 
+use codec::{Decode, Encode};
 use frame_support::{
     construct_runtime, parameter_types,
     traits::{Currency, FindAuthor, Imbalance, KeyOwnerProofSystem, Nothing, OnUnbalanced},
@@ -23,7 +24,7 @@ use sp_runtime::{
         NumberFor, Verify,
     },
     transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
-    ApplyExtrinsicResult, MultiSignature,
+    ApplyExtrinsicResult, MultiSignature, RuntimeDebug,
 };
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -302,7 +303,6 @@ impl pallet_dapps_staking::Config for Runtime {
 }
 
 /// Multi-VM pointer to smart contract instance.
-use codec::{Decode, Encode};
 #[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, RuntimeDebug)]
 pub enum SmartContract<AccountId> {
     /// EVM smart contract instance.
@@ -311,7 +311,7 @@ pub enum SmartContract<AccountId> {
     Wasm(AccountId),
 }
 
-impl<AccountId> IsContract for SmartContract<AccountId> {
+impl<AccountId> pallet_dapps_staking::traits::IsContract for SmartContract<AccountId> {
     fn is_contract(&self) -> bool {
         match self {
             SmartContract::Wasm(_account) => false,
@@ -412,8 +412,6 @@ impl fp_rpc::ConvertTransaction<sp_runtime::OpaqueExtrinsic> for TransactionConv
         &self,
         transaction: pallet_ethereum::Transaction,
     ) -> sp_runtime::OpaqueExtrinsic {
-        use codec::{Decode, Encode};
-
         let extrinsic = UncheckedExtrinsic::new_unsigned(
             pallet_ethereum::Call::<Runtime>::transact(transaction).into(),
         );

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -272,7 +272,7 @@ impl pallet_custom_signatures::Config for Runtime {
 
 parameter_types! {
     pub const BlockPerEra: BlockNumber = 1 * DAYS;
-    pub const RegisterDeposit: Balance = 100;
+    pub const RegisterDeposit: Balance = 100 * SDN;
     pub const DeveloperRewardPercentage: u32 = 80;
     pub const MaxNumberOfStakersPerContract: u32 = 128;
     pub const MinimumStakingAmount: Balance = 10;

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -271,7 +271,7 @@ impl pallet_custom_signatures::Config for Runtime {
 }
 
 parameter_types! {
-    pub const BlockPerEra: BlockNumber = 60;
+    pub const BlockPerEra: BlockNumber = 1 * DAYS;
     pub const RegisterDeposit: Balance = 100;
     pub const DeveloperRewardPercentage: u32 = 80;
     pub const MaxNumberOfStakersPerContract: u32 = 128;

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -4,6 +4,7 @@
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
 
+use codec::{Decode, Encode};
 use frame_support::{
     construct_runtime, match_type, parameter_types,
     traits::{Contains, Currency, FindAuthor, Imbalance, OnUnbalanced},
@@ -30,7 +31,7 @@ use sp_runtime::{
         OpaqueKeys, Verify,
     },
     transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
-    ApplyExtrinsicResult, FixedPointNumber, Perbill, Perquintill,
+    ApplyExtrinsicResult, FixedPointNumber, Perbill, Perquintill, RuntimeDebug,
 };
 use sp_std::prelude::*;
 
@@ -280,6 +281,7 @@ parameter_types! {
 impl pallet_dapps_staking::Config for Runtime {
     type Currency = Balances;
     type BlockPerEra = BlockPerEra;
+    type SmartContract = SmartContract<AccountId>;
     type RegisterDeposit = RegisterDeposit;
     type DeveloperRewardPercentage = DeveloperRewardPercentage;
     type Event = Event;
@@ -287,6 +289,24 @@ impl pallet_dapps_staking::Config for Runtime {
     type MaxNumberOfStakersPerContract = MaxNumberOfStakersPerContract;
     type MinimumStakingAmount = MinimumStakingAmount;
     type PalletId = DappsStakingPalletId;
+}
+
+/// Multi-VM pointer to smart contract instance.
+#[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, RuntimeDebug)]
+pub enum SmartContract<AccountId> {
+    /// EVM smart contract instance.
+    Evm(sp_core::H160),
+    /// Wasm smart contract instance.
+    Wasm(AccountId),
+}
+
+impl<AccountId> pallet_dapps_staking::traits::IsContract for SmartContract<AccountId> {
+    fn is_contract(&self) -> bool {
+        match self {
+            SmartContract::Wasm(_account) => false,
+            SmartContract::Evm(account) => EVM::account_codes(&account).len() > 0,
+        }
+    }
 }
 
 impl pallet_utility::Config for Runtime {
@@ -638,8 +658,6 @@ impl fp_rpc::ConvertTransaction<sp_runtime::OpaqueExtrinsic> for TransactionConv
         &self,
         transaction: pallet_ethereum::Transaction,
     ) -> sp_runtime::OpaqueExtrinsic {
-        use codec::{Decode, Encode};
-
         let extrinsic = UncheckedExtrinsic::new_unsigned(
             pallet_ethereum::Call::<Runtime>::transact(transaction).into(),
         );


### PR DESCRIPTION
@akru @Dinonard

please take a look at this commit.
The implementation of trait `IsContract` is placed in runtime in order to reach EVM module.
But now the visibility of fn `is_contract` in pallet-dapps-staking is moved as well and compiler complains with:
`
no variant or associated item namedis_contractfound for enumtraits::SmartContractin the current scope
`

please advice what would be the best approach to solve this
