### PR TITLE
added counter for individual rewards

### DIFF
--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -72,6 +72,7 @@ pub struct EraStakingPoints<AccountId: Ord, Balance: HasCompact> {
     /// Era when this contract was staked last time before this one.
     /// In case only a single staking era exists, it will be set to that one. This indicates the final element in the chain.
     former_staked_era: EraIndex,
+    paidout_rewards: Balance,
 }
 
 /// Multi-VM pointer to smart contract instance.

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -86,12 +86,7 @@ pub enum SmartContract<AccountId> {
 /// The ledger of a (bonded) stash.
 #[derive(PartialEq, Eq, Clone, Encode, Decode, Default, RuntimeDebug)]
 pub struct StakingLedger<Balance: HasCompact + Default> {
-    /// The total amount of the stash's balance that we are currently accounting for.
-    /// It's just `active` plus all the `unlocking` balances.
+    /// The total amount of the staker's balance that we are currently accounting for.
     #[codec(compact)]
     pub total: Balance,
-    /// The total amount of the stash's balance that will be at stake in any forthcoming
-    /// rounds.
-    #[codec(compact)]
-    pub active: Balance,
 }

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -72,7 +72,8 @@ pub struct EraStakingPoints<AccountId: Ord, Balance: HasCompact> {
     /// Era when this contract was staked last time before this one.
     /// In case only a single staking era exists, it will be set to that one. This indicates the final element in the chain.
     former_staked_era: EraIndex,
-    paidout_rewards: Balance,
+    /// Accrued and claimed rewards on this contract both for stakers and the developer
+    claimed_rewards: Balance,
 }
 
 /// Multi-VM pointer to smart contract instance.
@@ -82,12 +83,4 @@ pub enum SmartContract<AccountId> {
     Evm(sp_core::H160),
     /// Wasm smart contract instance.
     Wasm(AccountId),
-}
-
-/// The ledger of a (bonded) stash.
-#[derive(PartialEq, Eq, Clone, Encode, Decode, Default, RuntimeDebug)]
-pub struct StakingLedger<Balance: HasCompact + Default> {
-    /// The total amount of the staker's balance that we are currently accounting for.
-    #[codec(compact)]
-    pub total: Balance,
 }

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -829,6 +829,13 @@ pub mod pallet {
             for (s, b) in staker_map {
                 IndividualRewardCounter::<T>::mutate(contract, s, |balance| *balance += *b);
                 T::Currency::deposit_into_existing(&s, *b).ok();
+                println!(
+                    "{:?} s:{:?} b={:?} r={:?}",
+                    contract,
+                    s,
+                    *b,
+                    Self::reward_counter(&contract, s)
+                );
             }
         }
 

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -75,10 +75,10 @@ pub mod pallet {
         84u32
     }
 
-    /// Map from all (unlocked) "controller" accounts to the info regarding the staking.
+    /// Bonded amount for the staker
     #[pallet::storage]
     #[pallet::getter(fn ledger)]
-    pub(crate) type Ledger<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, BalanceOf<T>>;
+    pub(crate) type Ledger<T: Config> = StorageMap<_, Twox64Concat, T::AccountId, BalanceOf<T>>;
 
     /// Number of eras to keep in history.
     ///

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -178,3 +178,16 @@ pub(crate) fn check_rewards_and_counter(
         total_reward_per_era
     );
 }
+
+pub(crate) fn check_paidout_rewards_for_contract(
+    contract: &SmartContract<mock::AccountId>,
+    expected_contract_reward: mock::Balance,
+) {
+    let era_last_claimed = mock::DappsStaking::contract_last_claimed(contract).unwrap_or(0);
+    let contract_staking_info =
+        mock::DappsStaking::contract_era_stake(contract, era_last_claimed).unwrap_or_default();
+    assert_eq!(
+        contract_staking_info.paidout_rewards,
+        expected_contract_reward
+    )
+}

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -51,7 +51,7 @@ pub(crate) fn unbond_unstake_and_withdraw_with_verification(
 pub(crate) fn verify_ledger(staker_id: AccountId, staked_value: Balance) {
     // Verify that ledger storage values are as expected.
     let ledger = Ledger::<TestRuntime>::get(staker_id).unwrap();
-    assert_eq!(staked_value, ledger.total);
+    assert_eq!(staked_value, ledger);
 }
 
 /// Used to verify era staking points content.
@@ -159,26 +159,27 @@ pub(crate) fn calc_expected_developer_reward(
     Perbill::from_percent(DEVELOPER_REWARD_PERCENTAGE) * contract_reward
 }
 
-/// Check Balance after reward distribution and check reward counter
-pub(crate) fn check_rewards_and_counter(
+/// Check staker/dev Balance after reward distribution.
+/// Check that claimed rewards for staker/dev are updated.
+pub(crate) fn check_rewards_on_balance_and_storage(
     contract: &SmartContract<mock::AccountId>,
     user: &AccountId,
     free_balance: mock::Balance,
     eras: EraIndex,
     expected_era_reward: mock::Balance,
 ) {
-    println!("check_rewards_and_counter {:?}, user={:?}", contract, &user);
     let total_reward_per_era = expected_era_reward * eras as u128;
     assert_eq!(
         <mock::TestRuntime as Config>::Currency::free_balance(user),
         free_balance + total_reward_per_era
     );
     assert_eq!(
-        mock::DappsStaking::reward_counter(contract, user),
+        mock::DappsStaking::rewards_claimed(contract, user),
         total_reward_per_era
     );
 }
 
+/// Check that claimed rewards on this contract are updated
 pub(crate) fn check_paidout_rewards_for_contract(
     contract: &SmartContract<mock::AccountId>,
     expected_contract_reward: mock::Balance,
@@ -187,7 +188,7 @@ pub(crate) fn check_paidout_rewards_for_contract(
     let contract_staking_info =
         mock::DappsStaking::contract_era_stake(contract, era_last_claimed).unwrap_or_default();
     assert_eq!(
-        contract_staking_info.paidout_rewards,
+        contract_staking_info.claimed_rewards,
         expected_contract_reward
     )
 }

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -52,7 +52,6 @@ pub(crate) fn verify_ledger(staker_id: AccountId, staked_value: Balance) {
     // Verify that ledger storage values are as expected.
     let ledger = Ledger::<TestRuntime>::get(staker_id).unwrap();
     assert_eq!(staked_value, ledger.total);
-    assert_eq!(staked_value, ledger.active);
 }
 
 /// Used to verify era staking points content.
@@ -158,4 +157,24 @@ pub(crate) fn calc_expected_developer_reward(
 ) -> mock::Balance {
     let contract_reward = Perbill::from_rational(contract_stake, era_stake) * era_reward;
     Perbill::from_percent(DEVELOPER_REWARD_PERCENTAGE) * contract_reward
+}
+
+/// Check Balance after reward distribution and check reward counter
+pub(crate) fn check_rewards_and_counter(
+    contract: &SmartContract<mock::AccountId>,
+    user: &AccountId,
+    free_balance: mock::Balance,
+    eras: EraIndex,
+    expected_era_reward: mock::Balance,
+) {
+    println!("check_rewards_and_counter {:?}, user={:?}", contract, &user);
+    let total_reward_per_era = expected_era_reward * eras as u128;
+    assert_eq!(
+        <mock::TestRuntime as Config>::Currency::free_balance(user),
+        free_balance + total_reward_per_era
+    );
+    assert_eq!(
+        mock::DappsStaking::reward_counter(contract, user),
+        total_reward_per_era
+    );
 }

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1154,18 +1154,18 @@ fn claim_one_contract_one_staker() {
             calc_expected_developer_reward(total_era_dapps_reward, INITIAL_STAKE, INITIAL_STAKE);
 
         // check balances to see if the rewards are paid out
-        check_rewards_and_counter(
+        check_rewards_on_balance_and_storage(
             &contract,
             &staker1,
             free_balance_staker1,
-            eras_eligible_for_reward as u32,
+            eras_eligible_for_reward as EraIndex,
             expected_staker1_reward,
         );
-        check_rewards_and_counter(
+        check_rewards_on_balance_and_storage(
             &contract,
             &developer,
             free_developer_balance,
-            eras_eligible_for_reward as u32,
+            eras_eligible_for_reward as EraIndex,
             expected_developer_reward,
         );
         let expected_contract_reward =
@@ -1228,25 +1228,25 @@ fn claim_one_contract_two_stakers() {
 
         // check balances to see if the rewards are paid out
         let eras_eligible_for_reward = (claim_era - start_era) as u128;
-        check_rewards_and_counter(
+        check_rewards_on_balance_and_storage(
             &contract,
             &staker1,
             free_balance_staker1,
-            eras_eligible_for_reward as u32,
+            eras_eligible_for_reward as EraIndex,
             expected_staker1_reward,
         );
-        check_rewards_and_counter(
+        check_rewards_on_balance_and_storage(
             &contract,
             &staker2,
             free_balance_staker2,
-            eras_eligible_for_reward as u32,
+            eras_eligible_for_reward as EraIndex,
             expected_staker2_reward,
         );
-        check_rewards_and_counter(
+        check_rewards_on_balance_and_storage(
             &contract,
             &developer,
             free_developer_balance,
-            eras_eligible_for_reward as u32,
+            eras_eligible_for_reward as EraIndex,
             expected_developer_reward,
         );
         let expected_contract_reward = eras_eligible_for_reward
@@ -1371,33 +1371,33 @@ fn claim_two_contracts_three_stakers() {
         let expected_c1_staker1_reward_total = eras_eligible_for_reward1
             * expected_c1_staker1_e1_reward
             + eras_eligible_for_reward2 * expected_c1_staker1_e2_reward;
-        check_rewards_and_counter(
+        check_rewards_on_balance_and_storage(
             &contract1,
             &staker1,
             free_balance_staker1,
-            1 as u32, // use 1 since the multiplication with era is alreday done
+            1 as EraIndex, // use 1 since the multiplication with era is alreday done
             expected_c1_staker1_reward_total,
         );
         // staker2 staked on both contracts. Memorize this reward for staker2 on contract1
         let expected_c1_staker2_reward_total = eras_eligible_for_reward1
             * expected_c1_staker2_e1_reward
             + eras_eligible_for_reward2 * expected_c1_staker2_e2_reward;
-        check_rewards_and_counter(
+        check_rewards_on_balance_and_storage(
             &contract1,
             &staker2,
             free_balance_staker2,
-            1 as u32, // use 1 since the multiplication with era is alreday done
+            1 as EraIndex, // use 1 since the multiplication with era is alreday done
             expected_c1_staker2_reward_total,
         );
 
         let expected_c1_developer1_reward_total = eras_eligible_for_reward1
             * expected_c1_dev1_e1_reward
             + eras_eligible_for_reward2 * expected_c1_dev1_e2_reward;
-        check_rewards_and_counter(
+        check_rewards_on_balance_and_storage(
             &contract1,
             &developer1,
             free_balance_developer1,
-            1 as u32, // use 1 since the multiplication with era is alreday done
+            1 as EraIndex, // use 1 since the multiplication with era is alreday done
             expected_c1_developer1_reward_total,
         );
         let expected_contract1_reward = expected_c1_staker1_reward_total
@@ -1448,27 +1448,27 @@ fn claim_two_contracts_three_stakers() {
                 + expected_c1_staker2_reward_total
         );
 
-        // we do not use check_rewards_and_counter() here since
+        // we do not use check_rewards_on_balance_and_storage() here since
         // this counter check is for the contract2 only.
         // It does not include reward for the contract1
         assert_eq!(
-            mock::DappsStaking::reward_counter(contract2, staker2),
+            mock::DappsStaking::rewards_claimed(contract2, staker2),
             expected_c2_staker2_reward_total
         );
 
-        check_rewards_and_counter(
+        check_rewards_on_balance_and_storage(
             &contract2,
             &staker3,
             free_balance_staker3,
-            eras_eligible_for_reward as u32,
+            eras_eligible_for_reward as EraIndex,
             expected_c2_staker3_e2_reward,
         );
 
-        check_rewards_and_counter(
+        check_rewards_on_balance_and_storage(
             &contract2,
             &developer2,
             free_balance_developer2,
-            eras_eligible_for_reward as u32,
+            eras_eligible_for_reward as EraIndex,
             expected_c2_dev2_e2_reward,
         );
         let expected_contract2_reward = eras_eligible_for_reward

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1168,6 +1168,9 @@ fn claim_one_contract_one_staker() {
             eras_eligible_for_reward as u32,
             expected_developer_reward,
         );
+        let expected_contract_reward =
+            eras_eligible_for_reward * (expected_staker1_reward + expected_developer_reward);
+        check_paidout_rewards_for_contract(&contract, expected_contract_reward);
     })
 }
 
@@ -1246,6 +1249,9 @@ fn claim_one_contract_two_stakers() {
             eras_eligible_for_reward as u32,
             expected_developer_reward,
         );
+        let expected_contract_reward = eras_eligible_for_reward
+            * (expected_staker1_reward + expected_staker2_reward + expected_developer_reward);
+        check_paidout_rewards_for_contract(&contract, expected_contract_reward);
     })
 }
 
@@ -1394,6 +1400,10 @@ fn claim_two_contracts_three_stakers() {
             1 as u32, // use 1 since the multiplication with era is alreday done
             expected_c1_developer1_reward_total,
         );
+        let expected_contract1_reward = expected_c1_staker1_reward_total
+            + expected_c1_staker2_reward_total
+            + expected_c1_developer1_reward_total;
+        check_paidout_rewards_for_contract(&contract1, expected_contract1_reward);
 
         // claim rewards for contract2  4 eras later
         // era=11
@@ -1461,5 +1471,9 @@ fn claim_two_contracts_three_stakers() {
             eras_eligible_for_reward as u32,
             expected_c2_dev2_e2_reward,
         );
+        let expected_contract2_reward = eras_eligible_for_reward
+            * (expected_c2_staker3_e2_reward + expected_c2_dev2_e2_reward)
+            + expected_c2_staker2_reward_total;
+        check_paidout_rewards_for_contract(&contract2, expected_contract2_reward);
     })
 }

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1154,13 +1154,19 @@ fn claim_one_contract_one_staker() {
             calc_expected_developer_reward(total_era_dapps_reward, INITIAL_STAKE, INITIAL_STAKE);
 
         // check balances to see if the rewards are paid out
-        assert_eq!(
-            <mock::TestRuntime as Config>::Currency::free_balance(&staker1),
-            free_balance_staker1 + eras_eligible_for_reward * expected_staker1_reward
+        check_rewards_and_counter(
+            &contract,
+            &staker1,
+            free_balance_staker1,
+            eras_eligible_for_reward as u32,
+            expected_staker1_reward,
         );
-        assert_eq!(
-            <mock::TestRuntime as Config>::Currency::free_balance(&developer),
-            free_developer_balance + eras_eligible_for_reward * expected_developer_reward as u128
+        check_rewards_and_counter(
+            &contract,
+            &developer,
+            free_developer_balance,
+            eras_eligible_for_reward as u32,
+            expected_developer_reward,
         );
     })
 }
@@ -1219,17 +1225,26 @@ fn claim_one_contract_two_stakers() {
 
         // check balances to see if the rewards are paid out
         let eras_eligible_for_reward = (claim_era - start_era) as u128;
-        assert_eq!(
-            <mock::TestRuntime as Config>::Currency::free_balance(&staker1),
-            free_balance_staker1 + eras_eligible_for_reward * expected_staker1_reward
+        check_rewards_and_counter(
+            &contract,
+            &staker1,
+            free_balance_staker1,
+            eras_eligible_for_reward as u32,
+            expected_staker1_reward,
         );
-        assert_eq!(
-            <mock::TestRuntime as Config>::Currency::free_balance(&staker2),
-            free_balance_staker2 + eras_eligible_for_reward * expected_staker2_reward
+        check_rewards_and_counter(
+            &contract,
+            &staker2,
+            free_balance_staker2,
+            eras_eligible_for_reward as u32,
+            expected_staker2_reward,
         );
-        assert_eq!(
-            <mock::TestRuntime as Config>::Currency::free_balance(&developer),
-            free_developer_balance + eras_eligible_for_reward * expected_developer_reward as u128
+        check_rewards_and_counter(
+            &contract,
+            &developer,
+            free_developer_balance,
+            eras_eligible_for_reward as u32,
+            expected_developer_reward,
         );
     })
 }


### PR DESCRIPTION
Adding new storage double map to use as counter for accrued rewards per (contract, staker)
- [x] add storage
- [x] increase it after claim() for stakers and the developer
- [x] delete after total unbonding
- [x] update check for all UTs

Add reward counter per contract
- [x] Add new element in  EraStakingPoints struct and use as counter