### PR TITLE
Shiden dapps staking - increase max stakers 512 -> 1024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "local-runtime"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "evm",
  "fp-rpc",
@@ -9278,7 +9278,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -9345,7 +9345,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "3.0.2"
+version = "3.0.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar collator implementation in Rust."
 build = "build.rs"

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "3.0.2"
+version = "3.0.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "3.0.2"
+version = "3.0.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "3.0.2"
+version = "3.0.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "3.0.2"
+version = "3.0.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -84,7 +84,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 26,
+    spec_version: 27,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -267,7 +267,7 @@ parameter_types! {
     pub const BlockPerEra: BlockNumber = 1 * DAYS;
     pub const RegisterDeposit: Balance = 100 * SDN;
     pub const DeveloperRewardPercentage: Perbill = Perbill::from_percent(80);
-    pub const MaxNumberOfStakersPerContract: u32 = 512;
+    pub const MaxNumberOfStakersPerContract: u32 = 1024;
     pub const MinimumStakingAmount: Balance = 100 * SDN;
     pub const MinimumRemainingAmount: Balance = 1 * SDN;
     pub const HistoryDepth: u32 = 14;


### PR DESCRIPTION
**Pull Request Summary**

> Increase max number of stakers per contract in Shiden to 1024

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [x] updated spec version
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata

**This pull request makes the following changes:**

**Changes**
- Max number of stakers per contract in Shiden
