### PR TITLE
Shiden dapps staking supports 512 stakers

### DIFF
--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -267,7 +267,7 @@ parameter_types! {
     pub const BlockPerEra: BlockNumber = 1 * DAYS;
     pub const RegisterDeposit: Balance = 100 * SDN;
     pub const DeveloperRewardPercentage: Perbill = Perbill::from_percent(50);
-    pub const MaxNumberOfStakersPerContract: u32 = 1024;
+    pub const MaxNumberOfStakersPerContract: u32 = 512;
     pub const MinimumStakingAmount: Balance = 100 * SDN;
     pub const MinimumRemainingAmount: Balance = 1 * SDN;
     pub const HistoryDepth: u32 = 14;


### PR DESCRIPTION
**Pull Request Summary**

> Reduce max number of stakers for Shiden back to 512

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] updated spec version
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata
